### PR TITLE
dev: add concrete promo type and checker

### DIFF
--- a/iwfpapp/lib/services/config/consts/error_messages.dart
+++ b/iwfpapp/lib/services/config/consts/error_messages.dart
@@ -3,6 +3,7 @@ final String promoIdHasSpaceErrorMessage = 'Promotion ID cannot contain space.';
 final String promoIdEmptyErrorMessage = 'Promotion ID cannot be empty.';
 final String promoNameEmptyErrorMessage = 'Promotion name cannot be empty.';
 final String promoTypeEmptyErrorMessage = 'Promotion type cannot be empty.';
+final String promoTypeUnknownErrorMessage = 'Promotion type is unknwon.';
 final String promoStartEmptyErrorMessage =
     'Promotion start date cannot be empty.';
 final String promoEndEmptyErrorMessage = 'Promotion end date cannot be empty.';

--- a/iwfpapp/lib/services/config/consts/promo_type_lookup.dart
+++ b/iwfpapp/lib/services/config/consts/promo_type_lookup.dart
@@ -1,0 +1,7 @@
+import 'package:iwfpapp/services/config/typedefs/promo_types.dart';
+
+Map<String, CashbackPromoType> promoTypeLookup = {
+  'universal': CashbackPromoType.UNIVERSAL,
+  'sector': CashbackPromoType.SECTOR,
+  'brand': CashbackPromoType.BRAND,
+};

--- a/iwfpapp/lib/services/config/typedefs/promo_types.dart
+++ b/iwfpapp/lib/services/config/typedefs/promo_types.dart
@@ -1,0 +1,20 @@
+enum CashbackPromoType {
+  /// UNIVERSAL represents the type of
+  /// cash back promotion that applies to all
+  /// transactions. For example, Chase Pay
+  /// Apple Pay, etc
+  UNIVERSAL,
+  /// SECTOR represents the type of
+  /// cash back promotions that applies
+  /// to purchases in a certain sector.
+  /// For example, gas stations,
+  /// restaurants, drag stores, etc
+  SECTOR,
+  /// BRAND represents the type of
+  /// cash back promotions that applies
+  /// to purchase from certain brands.
+  /// For example, Walmart, Target,
+  /// BestBuy, etc
+  BRAND,
+}
+

--- a/iwfpapp/lib/services/config/typedefs/promo_types.dart
+++ b/iwfpapp/lib/services/config/typedefs/promo_types.dart
@@ -4,20 +4,22 @@ enum CashbackPromoType {
   /// transactions. For example, Chase Pay
   /// Apple Pay, etc
   UNIVERSAL,
+
   /// SECTOR represents the type of
   /// cash back promotions that applies
   /// to purchases in a certain sector.
   /// For example, gas stations,
   /// restaurants, drag stores, etc
   SECTOR,
+
   /// BRAND represents the type of
   /// cash back promotions that applies
   /// to purchase from certain brands.
   /// For example, Walmart, Target,
   /// BestBuy, etc
   BRAND,
+
   /// UNKNOWN is reserved for undefined
   /// types, mostly error
   UNKNOWN,
 }
-

--- a/iwfpapp/lib/services/config/typedefs/promo_types.dart
+++ b/iwfpapp/lib/services/config/typedefs/promo_types.dart
@@ -16,5 +16,8 @@ enum CashbackPromoType {
   /// For example, Walmart, Target,
   /// BestBuy, etc
   BRAND,
+  /// UNKNOWN is reserved for undefined
+  /// types, mostly error
+  UNKNOWN,
 }
 

--- a/iwfpapp/lib/services/utilities/converters/str2promo_type.dart
+++ b/iwfpapp/lib/services/utilities/converters/str2promo_type.dart
@@ -1,0 +1,10 @@
+import 'package:iwfpapp/services/config/consts/promo_type_lookup.dart';
+import 'package:iwfpapp/services/config/typedefs/promo_types.dart';
+
+CashbackPromoType str2promoType(String promoTypeStr) {
+  if (promoTypeLookup.containsKey(promoTypeStr)) {
+    return promoTypeLookup[promoTypeStr];
+  } else {
+    return CashbackPromoType.UNKNOWN;
+  }
+}

--- a/iwfpapp/lib/services/utilities/validators/promo_info_validator.dart
+++ b/iwfpapp/lib/services/utilities/validators/promo_info_validator.dart
@@ -1,5 +1,7 @@
 import 'package:iwfpapp/services/config/consts/error_messages.dart';
+import 'package:iwfpapp/services/config/typedefs/promo_types.dart';
 import 'package:iwfpapp/services/config/typedefs/validation_response.dart';
+import 'package:iwfpapp/services/utilities/converters/str2promo_type.dart';
 import 'package:iwfpapp/services/utilities/validators/category_info_validator.dart';
 import 'package:iwfpapp/services/utilities/validators/response_merger.dart';
 
@@ -25,11 +27,16 @@ ValidationResponse isValidPromoName(String promoName) {
   return response;
 }
 
-ValidationResponse isValidPromoType(String promoType) {
+ValidationResponse isValidPromoType(String promoTypeStr) {
   ValidationResponse response = ValidationResponse(valid: true);
-  if (promoType.isEmpty) {
+  if (promoTypeStr.isEmpty) {
     response.valid = false;
     response.messages.add(promoTypeEmptyErrorMessage);
+  }
+  CashbackPromoType promoType = str2promoType(promoTypeStr);
+  if (promoType == CashbackPromoType.UNKNOWN) {
+    response.valid = false;
+    response.messages.add(promoTypeUnknownErrorMessage);
   }
   return response;
 }


### PR DESCRIPTION
PR in 1 sentence: use an enum for promo types instead of string and add converter/checker.

Test: None

Closes: None