### PR TITLE
fix: xcode sim breaking change

### DIFF
--- a/.github/workflows/device_test_iwfpapp.yml
+++ b/.github/workflows/device_test_iwfpapp.yml
@@ -21,8 +21,9 @@ jobs:
     strategy:
       matrix:
         device:
-          - "iPhone 8 (13.1)"
-          - "iPhone 11 Pro Max (13.1)"
+          - "iPad Pro (12.9-inch) (3rd generation) (13.2.2)"
+          - "iPhone 11 Pro Max (13.2.2)"
+          - "iPad (7th generation) (13.2.2)"
       fail-fast: false
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
PR in 1 sentence: xcode had a breaking change where the device name is different now. This PR changes the name to match it.

Test: none

Closes: none