### PR TITLE
fix: remove ipad 7 as it's not supported

### DIFF
--- a/.github/workflows/device_test_iwfpapp.yml
+++ b/.github/workflows/device_test_iwfpapp.yml
@@ -24,7 +24,6 @@ jobs:
         device:
           - "iPad Pro (12.9-inch) (3rd generation) (13.3)"
           - "iPhone 11 Pro Max (13.3)"
-          - "iPad (7th generation) (13.3)"
       fail-fast: false
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
PR in 1 sentence: remove iPad 7 from the device tests as it seems that it is no longer supported in the toolchain.

Test: none

Closes: none

<a href="https://gitpod.io/#https://github.com/tianhaoz95/iwfp/pull/321"><img src="https://gitpod.io/api/apps/github/pbs/github.com/tianhaoz95/iwfp.git/8571b79d0f8b77337c36415e65a85453bfc53f52.svg" /></a>

