### PR TITLE
allow fractional cash back rate

### DIFF
--- a/iwfpapp/lib/screens/add_promo/main.dart
+++ b/iwfpapp/lib/screens/add_promo/main.dart
@@ -120,7 +120,7 @@ class _AddPromoScreen extends State<AddPromoScreen> {
     setState(() {
       status = SubmitScreenStatus.LOADING;
     });
-    int promoRate = int.parse(promoRateStr);
+    double promoRate = double.parse(promoRateStr);
     CashbackPromo promo = CashbackPromo(
         promoName,
         promoId,

--- a/iwfpapp/lib/services/config/typedefs/cashback_promo.dart
+++ b/iwfpapp/lib/services/config/typedefs/cashback_promo.dart
@@ -13,7 +13,7 @@ class CashbackPromo {
   /// * annual (repeats annually between start and end)
   /// * const (constant, always the same. In this case, start and end are ignored)
   final String repeat;
-  final int rate;
+  final double rate;
   const CashbackPromo(this.name, this.id, this.type, this.start, this.end,
       this.repeat, this.rate, this.category);
 }

--- a/iwfpapp/lib/services/utilities/converters/dynamic2rate.dart
+++ b/iwfpapp/lib/services/utilities/converters/dynamic2rate.dart
@@ -1,11 +1,14 @@
 /// Converts dynamic type to cashback rate
-int dynamic2rate(dynamic dynamicRate) {
-  int promoRate = 0;
+double dynamic2rate(dynamic dynamicRate) {
+  double promoRate = 0;
   if (dynamicRate is int) {
+    promoRate = dynamicRate.toDouble();
+  } else if (dynamicRate is double) {
     promoRate = dynamicRate;
-  }
-  if (dynamicRate is String) {
-    promoRate = int.parse(dynamicRate);
+  } else if (dynamicRate is String) {
+    promoRate = double.parse(dynamicRate);
+  } else {
+    throw 'dynamicRate is not a number';
   }
   return promoRate;
 }

--- a/iwfpapp/lib/services/utilities/rankers/card_reward_ranker.dart
+++ b/iwfpapp/lib/services/utilities/rankers/card_reward_ranker.dart
@@ -4,8 +4,8 @@ import 'package:iwfpapp/services/config/typedefs/credit_card.dart';
 import 'package:iwfpapp/services/config/typedefs/shop_category.dart';
 import 'package:iwfpapp/services/utilities/validators/card_expiration_validator.dart';
 
-int getMaxRate(CreditCard card, ShopCategory category) {
-  int maxRate = 0;
+double getMaxRate(CreditCard card, ShopCategory category) {
+  double maxRate = 0.0;
   for (CashbackPromo promo in card.promos) {
     if (isInValidTimeRange(promo)) {
       if (promo.category.id == category.id) {
@@ -22,8 +22,8 @@ int getMaxRate(CreditCard card, ShopCategory category) {
 
 void rankCards(List<CreditCard> cards, ShopCategory category) {
   cards.sort((CreditCard cardLhs, CreditCard cardRhs) {
-    int maxLhsRate = getMaxRate(cardLhs, category);
-    int maxRhsRate = getMaxRate(cardRhs, category);
+    double maxLhsRate = getMaxRate(cardLhs, category);
+    double maxRhsRate = getMaxRate(cardRhs, category);
     return maxRhsRate.compareTo(maxLhsRate);
   });
 }

--- a/iwfpapp/lib/widgets/credit_cards/basic.dart
+++ b/iwfpapp/lib/widgets/credit_cards/basic.dart
@@ -21,7 +21,7 @@ class BasicCreditCard extends StatelessWidget {
     if (cardMetaData.name != null) {
       showCardName = cardMetaData.name;
       if (targetCategory != null) {
-        int maxRate = getMaxRate(cardMetaData, targetCategory);
+        double maxRate = getMaxRate(cardMetaData, targetCategory);
         showCardName = showCardName + ' w/ rate @ ' + maxRate.toString() + '%';
       }
     }

--- a/iwfpapp/lib/widgets/promos/chip.dart
+++ b/iwfpapp/lib/widgets/promos/chip.dart
@@ -11,7 +11,7 @@ class PromotionChip extends StatelessWidget {
     if (promo.name != null) {
       promoName = promo.category.name;
     }
-    int promoRate = -1;
+    double promoRate = 0.0;
     if (promo.rate != null) {
       promoRate = promo.rate;
     }

--- a/iwfpapp/test/unit/ranker_test.dart
+++ b/iwfpapp/test/unit/ranker_test.dart
@@ -4,9 +4,9 @@ import 'package:iwfpapp/services/config/typedefs/shop_category.dart';
 import 'package:iwfpapp/services/utilities/rankers/card_reward_ranker.dart';
 import 'package:test/test.dart';
 
-CreditCard generateCreditCard(String name, String id, List<int> rates) {
+CreditCard generateCreditCard(String name, String id, List<double> rates) {
   CreditCard card = CreditCard(name, id);
-  for (int rate in rates) {
+  for (double rate in rates) {
     CashbackPromo promo = CashbackPromo('Coffee Shop', 'coffee_shop', 'sector',
         'na', 'na', 'const', rate, ShopCategory('Coffee Shop', 'coffee_shop'));
     card.promos.add(promo);


### PR DESCRIPTION
PR in 1 sentence: as there are more tricks in cashback, there are now banks offering 1.5% cashback, so adding fractional rate support.

Test: unit test

Closes #304 

<a href="https://gitpod.io/#https://github.com/tianhaoz95/iwfp/pull/341"><img src="https://gitpod.io/api/apps/github/pbs/github.com/tianhaoz95/iwfp.git/44bab7be20ddaad83b8032d50bce30111e4e22b7.svg" /></a>

