### PR TITLE
dev: clean up replacement nav

### DIFF
--- a/app/lib/screens/add_card/add_card_form.dart
+++ b/app/lib/screens/add_card/add_card_form.dart
@@ -58,7 +58,8 @@ class _AddCardScreenAddCardFormContent
             child: Text('From Template', style: TextStyle(color: Colors.white)),
             key: Key('go_to_add_card_from_template_btn'),
             onPressed: () {
-              Navigator.pushReplacementNamed(context, '/add_card_from_template');
+              Navigator.pushReplacementNamed(
+                  context, '/add_card_from_template');
             },
           )),
           ListViewItem(

--- a/app/lib/screens/add_card/add_card_form.dart
+++ b/app/lib/screens/add_card/add_card_form.dart
@@ -58,7 +58,7 @@ class _AddCardScreenAddCardFormContent
             child: Text('From Template', style: TextStyle(color: Colors.white)),
             key: Key('go_to_add_card_from_template_btn'),
             onPressed: () {
-              Navigator.pushNamed(context, '/add_card_from_template');
+              Navigator.pushReplacementNamed(context, '/add_card_from_template');
             },
           )),
           ListViewItem(

--- a/app/lib/screens/add_card/card_added.dart
+++ b/app/lib/screens/add_card/card_added.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:iwfpapp/services/config/typedefs/home_tab_id.dart';
 import 'package:iwfpapp/services/data_backend/base_data_backend.dart';
 import 'package:iwfpapp/widgets/layouts/listview_item.dart';
 import 'package:provider/provider.dart';

--- a/app/lib/screens/add_card/card_added.dart
+++ b/app/lib/screens/add_card/card_added.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:iwfpapp/services/config/typedefs/home_tab_id.dart';
+import 'package:iwfpapp/services/data_backend/base_data_backend.dart';
 import 'package:iwfpapp/widgets/layouts/listview_item.dart';
+import 'package:provider/provider.dart';
 
 class AddCardScreenCardAddedContent extends StatefulWidget {
   final bool autoNav;
@@ -25,8 +27,8 @@ class _AddCardScreenCardAddedContent
 
   Future<void> navToWallet() async {
     await Future.delayed(Duration(milliseconds: 200));
-    Navigator.pushReplacementNamed(context, '/',
-        arguments: HomeTabId.CARD_MANAGEMENT);
+    Navigator.pop(context);
+    Provider.of<DataBackend>(context, listen: false).maybeRefresh();
   }
 
   @override

--- a/app/lib/screens/add_card_from_template/card_added_from_template.dart
+++ b/app/lib/screens/add_card_from_template/card_added_from_template.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:iwfpapp/services/config/typedefs/home_tab_id.dart';
+import 'package:iwfpapp/services/data_backend/base_data_backend.dart';
 import 'package:iwfpapp/widgets/layouts/listview_item.dart';
+import 'package:provider/provider.dart';
 
 class CardAddedFromTemplate extends StatefulWidget {
   final bool autoNav;
@@ -24,9 +26,8 @@ class _CardAddedFromTemplate extends State<CardAddedFromTemplate> {
 
   Future<void> navToWallet() async {
     await Future.delayed(Duration(milliseconds: 200));
+    Provider.of<DataBackend>(context,listen: false).maybeRefresh();
     Navigator.pop(context);
-    Navigator.pushReplacementNamed(context, '/',
-        arguments: HomeTabId.CARD_MANAGEMENT);
   }
 
   @override

--- a/app/lib/screens/add_card_from_template/card_added_from_template.dart
+++ b/app/lib/screens/add_card_from_template/card_added_from_template.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:iwfpapp/services/config/typedefs/home_tab_id.dart';
 import 'package:iwfpapp/services/data_backend/base_data_backend.dart';
 import 'package:iwfpapp/widgets/layouts/listview_item.dart';
 import 'package:provider/provider.dart';
@@ -26,7 +25,7 @@ class _CardAddedFromTemplate extends State<CardAddedFromTemplate> {
 
   Future<void> navToWallet() async {
     await Future.delayed(Duration(milliseconds: 200));
-    Provider.of<DataBackend>(context,listen: false).maybeRefresh();
+    Provider.of<DataBackend>(context, listen: false).maybeRefresh();
     Navigator.pop(context);
   }
 

--- a/app/lib/screens/home/home_screen.dart
+++ b/app/lib/screens/home/home_screen.dart
@@ -69,7 +69,7 @@ class _HomeScreen extends State<HomeScreen> {
     if (currentTabId == HomeTabId.CARD_MANAGEMENT) {
       return FloatingActionButton(
         onPressed: () {
-          Navigator.pushReplacementNamed(context, '/add_card');
+          Navigator.pushNamed(context, '/add_card');
         },
         key: Key('add_card_floating_btn'),
         child: Icon(Icons.add),

--- a/app/lib/services/data_backend/mock_data_backend.dart
+++ b/app/lib/services/data_backend/mock_data_backend.dart
@@ -2,15 +2,12 @@ import 'package:iwfpapp/services/config/typedefs/cashback_promo.dart';
 import 'package:iwfpapp/services/config/typedefs/data_store.dart';
 import 'package:iwfpapp/services/config/typedefs/credit_card.dart';
 import 'package:iwfpapp/services/data_backend/base_data_backend.dart';
-import 'package:iwfpapp/services/utilities/card_templates/template_getter.dart';
 
 class MockDataBackend extends DataBackend {
   Map<String, CreditCard> cardDatabase;
 
   MockDataBackend() : super() {
     cardDatabase = {};
-    CreditCard randomCard = getRandomCreditCardTemplate();
-    cardDatabase[randomCard.id] = randomCard;
   }
 
   @override


### PR DESCRIPTION
Previously, for simplicity, all the navigation uses push and replacement. However, this is not android friendly since pressing the button navigation key will quit the application. This PR changes all of them to stack navigation.

<a href="https://gitpod.io/#https://github.com/tianhaoz95/iwfp/pull/472"><img src="https://gitpod.io/api/apps/github/pbs/github.com/tianhaoz95/iwfp.git/21ebfc4d7528cace60716f006c97c9ccb15885f0.svg" /></a>

