### PR TITLE
fix: remove duplicated category in chase freedom template

### DIFF
--- a/app/lib/services/utilities/card_templates/chase_freedom.dart
+++ b/app/lib/services/utilities/card_templates/chase_freedom.dart
@@ -4,7 +4,7 @@ import 'package:iwfpapp/services/config/typedefs/shop_category.dart';
 
 CreditCard chaseFreedom = CreditCard(
   'Chase Freedom',
-  'chase freedom',
+  'chase_freedom',
   promos: [
     CashbackPromo(
       'Gas Station',
@@ -29,8 +29,6 @@ CreditCard chaseFreedom = CreditCard(
         'annual',
         5,
         ShopCategory('Home Improvement Stores', 'home_improvement_stores')),
-    CashbackPromo('Gas Stations', 'gas_stations', 'sector', '07/01', '09/30',
-        'annual', 5, ShopCategory('Gas Stations', 'gas_stations')),
     CashbackPromo(
         'Streaming Services',
         'streaming_services',

--- a/app/lib/services/utilities/converters/data2cards.dart
+++ b/app/lib/services/utilities/converters/data2cards.dart
@@ -56,7 +56,7 @@ List<CreditCard> data2cards(HttpsCallableResult rawResponse) {
     Map<String, dynamic> docs = Map<String, dynamic>.from(rawResponse.data);
     return docs2cards(docs);
   } catch (err) {
-    print('Error parsing cards: ' + err.toString());
-    return [];
+    String errMsg = 'Error parsing cards: ' + err.toString();
+    throw errMsg;
   }
 }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -11,7 +11,7 @@ description: A utility to help credit card users maximize cashback reward across
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.1.8+49
+version: 1.1.9+50
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/functions/src/handler/add_credit_card_with_template.ts
+++ b/functions/src/handler/add_credit_card_with_template.ts
@@ -29,7 +29,7 @@ async function addCreditCardWithTemplateHandler(
         // know.
         console.log("start adding " + promo.promo.id);
         await addPromoHandler(promo, context, provider);
-        console.log("finished adding" + promo.promo.id);
+        console.log("finished adding " + promo.promo.id);
       }
       return;
     }

--- a/functions/src/handler/get_credit_cards.ts
+++ b/functions/src/handler/get_credit_cards.ts
@@ -7,6 +7,14 @@ async function getCreditCardsHandler(data, context: FunctionContext, provider) {
     const userRef = provider.getUserRef(userUid);
     const cardRef = userRef.collection("cards");
     const cardSnap: FirebaseFirestore.QuerySnapshot = await cardRef.get();
+    console.log(
+      "cards under the user " +
+        userUid +
+        " with size " +
+        cardSnap.size +
+        " are: " +
+        cardSnap.docs
+    );
     const response = {};
     for (const card of cardSnap.docs) {
       console.log("retrieve card: ", card.id, "=>", card.data());


### PR DESCRIPTION
This PR removes a duplicated promotion, gas station, in the chase freedom credit card template to avoid errors when adding credit cards from templates.


<a href="https://gitpod.io/#https://github.com/tianhaoz95/iwfp/pull/499"><img src="https://gitpod.io/api/apps/github/pbs/github.com/tianhaoz95/iwfp.git/991587347c908d42dc291aaee9e4efa4365df219.svg" /></a>

