### PR TITLE
fix: trying changing the error message tag

### DIFF
--- a/app/android/fastlane/Fastfile
+++ b/app/android/fastlane/Fastfile
@@ -28,7 +28,7 @@ platform :android do
         skip_upload_images: true
       )
     rescue => exception
-      raise exception unless exception.message.include?('apkNotificationMessageKeyUpgradeVersionConflict')
+      raise exception unless exception.message.include?('APK specifies a version code that has already been used.')
       puts 'Current version already present on the Play Store. Omitting this upload.'
     end
   end


### PR DESCRIPTION
It seems that the previous error tag has been deprecated, trying if this new one works.

<!--
  To override the default commit message created by
  the pull request, add a override section.
  For details, please see:
  https://doc.mergify.io/actions.html#defining-the-commit-message
-->


<a href="https://gitpod.io/#https://github.com/tianhaoz95/iwfp/pull/682"><img src="https://gitpod.io/api/apps/github/pbs/github.com/tianhaoz95/iwfp.git/cb401204cf07a85017348bd4daabeddfb8bb7ca0.svg" /></a>

