### PR TITLE
chore: upgrade node version to 10

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -18,7 +18,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "8"
+    "node": "12"
   },
   "main": "lib/src/index.js",
   "dependencies": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -18,7 +18,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "12"
+    "node": "10"
   },
   "main": "lib/src/index.js",
   "dependencies": {


### PR DESCRIPTION
Firebase cloud functions are dropping support for node 8 per https://firebase.google.com/support/faq?authuser=0#expandable-10-label, so boost the node version to 12.

<!--
  To override the default commit message created by
  the pull request, add a override section.
  For details, please see:
  https://doc.mergify.io/actions.html#defining-the-commit-message
-->


<a href="https://gitpod.io/#https://github.com/tianhaoz95/iwfp/pull/692"><img src="https://gitpod.io/api/apps/github/pbs/github.com/tianhaoz95/iwfp.git/dd8badc3e5950280d4860e27e2dc9b75681f7739.svg" /></a>

